### PR TITLE
fixes /ensime/ensime-atom#27.  

### DIFF
--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -78,7 +78,11 @@ module.exports = Ensime =
 
     # Need to have a started server and port file
     @subscriptions.add atom.commands.add 'atom-workspace', "ensime:update-ensime-server", => updateEnsimeServer()
-    @subscriptions.add atom.commands.add 'atom-workspace', "ensime:start", => @initProject()
+    @subscriptions.add atom.commands.add 'atom-workspace', "ensime:start", =>
+      if !projectPath()?
+        modalMsg("no valid Ensime project found (did you remember to generate a .ensime file?)")
+      else @initProject()
+
     @subscriptions.add atom.commands.add 'atom-workspace', "ensime:stop", => @stopEnsime()
 
     @subscriptions.add atom.commands.add 'atom-workspace', "ensime:typecheck-all", => @typecheckAll()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,4 +1,5 @@
 path = require 'path'
+fs = require 'fs'
 
 isScalaSource = (editor) ->
   buffer = editor.getBuffer()
@@ -35,7 +36,7 @@ modalMsg = (title, msg) ->
       Ok: ->
 
 
-projectPath = -> atom.project.getPaths()[0]
+projectPath = -> (p for p in atom.project.getPaths() when fs.existsSync(p+"/.ensime"))[0]
 
 module.exports = {
   isScalaSource,


### PR DESCRIPTION
Filter potential project paths by whether or not path/.ensime is included.  Fail gracefully and descriptively when unable to find .ensime in any project path
