### PR TITLE
Clearer default colours and font size for errors

### DIFF
--- a/styles/ensime.less
+++ b/styles/ensime.less
@@ -32,3 +32,23 @@
     display: none;
   }
 }
+
+.ensime-status {
+  color : @text-color-info;
+}
+
+.am-panel {
+  font-size : larger;
+}
+
+.line-message div {
+  color : @text-color;
+}
+
+.line-message div.highlight-error {
+  color : @text-color-selected;
+}
+
+.line-message div.highlight-warning {
+  color : @text-color-selected;
+}


### PR DESCRIPTION
[As discussed](https://gitter.im/ensime/ensime-atom?at=56360850e4bb7eee53801b99), a few style changes.  Rather than hard-code colours as I did in the example posted to gitter, I've used [styleguide values](https://github.com/atom/styleguide) mostly. This should behave reasonably under different themes.

E.g.,

**Atom Dark**
![atom-dark](https://cloud.githubusercontent.com/assets/102661/10870026/3020b37c-80b8-11e5-97c4-b375e8fd40f2.png)

**Atom Light**
![atom-light](https://cloud.githubusercontent.com/assets/102661/10870028/35010482-80b8-11e5-9374-e1ae7e6b2395.png)
