### PR TITLE
Replace `scandal` file matcher with `glob`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Ensime",
   "main": "./lib/ensime",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Ensime integration for atom",
   "repository": "https://github.com/ensime/ensime-atom",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "jquery": "^2",
     "lodash": "~3.9.3",
     "recursive-readdir": "^1.3.0",
-    "scandal": "^2.2.0",
+    "glob": "~6.0.4",
     "sub-atom": "~1.0.0",
     "vue": "1.0.0-csp"
   },


### PR DESCRIPTION
- now uses [glob](https://github.com/isaacs/node-glob) to search `.ensime` files
- see #112 for more details
