### PR TITLE
Return error window output to default font size.

### DIFF
--- a/styles/ensime.less
+++ b/styles/ensime.less
@@ -37,10 +37,6 @@
   color : @text-color-info;
 }
 
-.am-panel {
-  font-size : larger;
-}
-
 .line-message div {
   color : @text-color;
 }


### PR DESCRIPTION
Fixes #134 

Back to a default font size. Looks like this with that lovely native-ui:

![slack scala users richard developer wip slash 2016-01-31 15-41-23](https://cloud.githubusercontent.com/assets/102661/12703062/2c7d5bec-c831-11e5-8d8e-859eb34fb3aa.png)
