### PR TITLE
Fix typo in README documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ENSIME integration includes the following features for Scala developers:
 
 ## Full Documentation
 
-Documentation is available at [ensime.org](http://ensime.org/editord/atom/)
+Documentation is available at [ensime.org](http://ensime.org/editors/atom/)
 
 
 ## Getting Started Summary


### PR DESCRIPTION
This fixes a typo in the link to ensime.org's atom documentation page.
