### PR TITLE
Waiting for http file to appear

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ENSIME integration includes the following features for Scala developers:
 - Format source file
 - Show implicits
 - Go to type
+- Go to documentation
 - Organize imports
 
 ## Full Documentation


### PR DESCRIPTION
Related to my comment on waiting for the `http` file in #144, here's a change to do that.

`chokidar.watch` is supposed to accept an array of files to watch, but when I tried that, I only ever saw "add" events for one file (the last in the array). So no idea what's going on there.  I ended up writing a recursive thing to watch on each file on turn.

Tried it on Mac and Ubuntu.
