### PR TITLE
Browse All Documentation

### DIFF
--- a/keymaps/ensime.cson
+++ b/keymaps/ensime.cson
@@ -8,3 +8,4 @@
   'cmd-ctrl-i': 'ensime:show-implicits'
   'cmd-shift-t': 'ensime:search-public-symbol'
   'ctrl-alt-d': 'ensime:go-to-doc'
+  'ctrl-alt-D': 'ensime:browse-doc'

--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -86,19 +86,14 @@ class Client
       file: editor.getBuffer().getPath()
       point: point
 
-    openDoc = (text) =>
-      url = Documentation.formUrl("localhost", @httpPort, text)
-      split = atom.config.get('Ensime.documentationSplit')
-      #console.log("OPENING", url, split)
-      switch split
-        when 'external-browser' then shell.openExternal(url)
-        else atom.workspace.open(url, {split: split})
-
     @post(req, (msg) =>
       switch msg.typehint
         when "FalseResponse" then log("no doc")
-        else openDoc(msg.text)
+        else Documentation.openDoc(Documentation.formUrl("localhost", @httpPort, msg.text))
     )
+
+  goToDocIndex: () ->
+    Documentation.openDoc("http://localhost:#{@httpPort}/docs")
 
   goToTypeAtPoint: (textBuffer, bufferPosition) =>
     offset = textBuffer.characterIndexForPosition(bufferPosition)

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -117,6 +117,7 @@ module.exports = Ensime =
     @startedCommands.add atom.commands.add scalaSourceSelector, "ensime:go-to-definition", => @goToDefinitionOfCursor()
 
     @startedCommands.add atom.commands.add scalaSourceSelector, "ensime:go-to-doc", => @goToDocOfCursor()
+    @startedCommands.add atom.commands.add scalaSourceSelector, "ensime:browse-doc", => @goToDocIndex()
 
     @startedCommands.add atom.commands.add scalaSourceSelector, "ensime:format-source", => @formatCurrentSourceFile()
 
@@ -336,6 +337,10 @@ module.exports = Ensime =
   goToDocOfCursor: ->
     editor = atom.workspace.getActiveTextEditor()
     @clientOfEditor(editor)?.goToDocAtPoint(editor)
+
+  goToDocIndex: ->
+    editor = atom.workspace.getActiveTextEditor()
+    @clientOfEditor(editor)?.goToDocIndex()
 
   goToDefinitionOfCursor: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/features/documentation.coffee
+++ b/lib/features/documentation.coffee
@@ -31,4 +31,10 @@ class Documentation
     alreadyUrl = (path.indexOf("//") != -1)
     if alreadyUrl then path else "http://#{host}:#{port}/#{path}"
 
+  @openDoc = (url) =>
+    split = atom.config.get('Ensime.documentationSplit')
+    switch split
+      when 'external-browser' then shell.openExternal(url)
+      else atom.workspace.open(url, {split: split})
+
 module.exports = Documentation


### PR DESCRIPTION
Sometimes ENSIME can't find the documentation under the cursor.  This PR adds the ability to open the documentation index.

ctrl-alt-shift-d produces....

![docs users richard developer wip slash 2016-02-07 14-57-43](https://cloud.githubusercontent.com/assets/102661/12873043/bef8bf14-cdab-11e5-9754-257ab9f1d47e.png)

...and then you can click into any package and browse the documentation.
