### PR TITLE
Remove left, top, bottom doc options

### DIFF
--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -82,7 +82,7 @@ module.exports = Ensime =
       description: "Where to open ScalaDoc"
       type: 'string'
       default: 'right'
-      enum: ['right', 'left', 'top', 'bottom', 'external-browser']
+      enum: ['right', 'external-browser']
       order: 12
 
   addCommandsForStoppedState: ->


### PR DESCRIPTION
Fixes: #162

Yeah, they don't work as I expected.  Right and external browser stay.
