### PR TITLE
Changing instructions from gen-ensime to ensimeConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Documentation is available at [ensime.org](http://ensime.org/editors/atom/)
 ## Getting Started Summary
 
 1. After installation go to the Atom ENSIME package settings and set the path to sbt.
-2. Use the `gen-ensime` command in sbt to generate a _.ensime_ file.
+2. Use the `ensimeConfig` command in sbt to generate a _.ensime_ file.
 3.  cmd-shift-P Ensime: Start
 
 See the full documentation for more details.

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -252,7 +252,7 @@ module.exports = Ensime =
 
 
       if(filteredDotEnsime.length == 0)
-        utils().modalMsg("No .ensime file found. Please generate with `sbt gen-ensime` or similar")
+        utils().modalMsg("No .ensime file found. Please generate with `sbt ensimeConfig` or similar")
       else if (filteredDotEnsime.length == 1)
         callback(filteredDotEnsime[0])
       else


### PR DESCRIPTION
Changing instructions from gen-ensime to ensimeConfig when first invoking sbt to generate the .ensime file.
