### PR TITLE
Do not start autocomplete after {, }, [, ], (, )

### DIFF
--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -7,12 +7,12 @@ c = (resolve) ->
   ->
     x ?= resolve()
     x
-  
+
 lodash = c -> require 'lodash'
 ensimeClient = c -> require 'ensime-client'
 ensimeStartup = c -> require './ensime-startup'
 utils = c -> require './utils'
-  
+
 AutocompletePlusProvider = require './features/autocomplete-plus'
 ImportSuggestions = require './features/import-suggestions'
 Refactorings = require './features/refactorings'
@@ -32,7 +32,7 @@ scalaSourceSelector = """atom-text-editor[data-grammar="source scala"]"""
 module.exports = Ensime =
 
   config: require './config'
-    
+
   addCommandsForStoppedState: ->
     @stoppedCommands = new CompositeDisposable
     @stoppedCommands.add atom.commands.add 'atom-workspace', "ensime:start", => @selectAndBootAnEnsime()
@@ -43,7 +43,7 @@ module.exports = Ensime =
     @startedCommands.add atom.commands.add 'atom-workspace', "ensime:stop", => @selectAndStopAnEnsime()
     @startedCommands.add atom.commands.add 'atom-workspace', "ensime:start", => @selectAndBootAnEnsime()
     @startedCommands.add atom.commands.add 'atom-workspace', "ensime:update-server", => @selectAndUpdateAnEnsime()
-    
+
 
     @startedCommands.add atom.commands.add scalaSourceSelector, "ensime:mark-implicits", => @markImplicits()
     @startedCommands.add atom.commands.add scalaSourceSelector, "ensime:unmark-implicits", => @unmarkImplicits()
@@ -67,7 +67,7 @@ module.exports = Ensime =
 
   activate: (state) ->
     logLevel = atom.config.get('Ensime.logLevel')
-    
+
     logapi = require('loglevel')
 
     logapi.getLogger('ensime.client').setLevel(logLevel)
@@ -93,7 +93,7 @@ module.exports = Ensime =
 
     @addCommandsForStoppedState()
     @someInstanceStarted = false
-    
+
     @controlSubscription = atom.workspace.observeTextEditors (editor) =>
       if utils().isScalaSource(editor)
         instanceLookup = => @instanceManager?.instanceOfFile(editor.getPath())
@@ -108,7 +108,7 @@ module.exports = Ensime =
 
     clientLookup = (editor) => @clientOfEditor(editor)
     @autocompletePlusProvider = new AutocompletePlusProvider(clientLookup)
-  
+
     @importSuggestions = new ImportSuggestions
     @refactorings = new Refactorings
 
@@ -210,7 +210,7 @@ module.exports = Ensime =
 
     ensimeStartup().startClient(dotEnsime, @statusbarOutput(statusbarView, typechecking), (client) =>
       atom.notifications.addSuccess("Ensime connected!")
-      
+
       # atom specific ui state of an instance
       ui = {
         statusbarView
@@ -278,12 +278,12 @@ module.exports = Ensime =
       @switchToInstance(undefined)
 
     @selectDotEnsime(stopDotEnsime, (dotEnsime) => @instanceManager?.isStarted(dotEnsime.path))
-  
+
   selectAndUpdateAnEnsime: ->
     @selectDotEnsime (selectedDotEnsime) ->
       dotEnsime = dotEnsimeUtils().parseDotEnsime(selectedDotEnsime.path)
       ensimeStartup().updateEnsimeServer(dotEnsime, -> atom.notifications.addSuccess("Updated!"))
-    
+
 
   typecheckAll: ->
     @clientOfActiveTextEditor()?.post( {"typehint": "TypecheckAllReq"}, (msg) ->)
@@ -341,7 +341,7 @@ module.exports = Ensime =
 
       getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         provider = getProvider()
-        if(provider)
+        if (provider && !'[](){}'.includes(prefix))
           new Promise (resolve) ->
             log.trace('ensime.getSuggestions')
             provider.getCompletions(editor.getBuffer(), bufferPosition, resolve)

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -341,7 +341,7 @@ module.exports = Ensime =
 
       getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         provider = getProvider()
-        if (provider && !'[](){}_'.includes(prefix))
+        if (provider && !'[](){}_ '.includes(prefix))
           new Promise (resolve) ->
             log.trace('ensime.getSuggestions')
             provider.getCompletions(editor.getBuffer(), bufferPosition, resolve)

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -341,7 +341,8 @@ module.exports = Ensime =
 
       getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         provider = getProvider()
-        if (provider && /[a-z.]/i.test(prefix))
+        
+        if (provider && !"[](){}_".includes(prefix))
           new Promise (resolve) ->
             log.trace('ensime.getSuggestions')
             provider.getCompletions(editor.getBuffer(), bufferPosition, resolve)

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -341,7 +341,7 @@ module.exports = Ensime =
 
       getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         provider = getProvider()
-        if (provider && !'[](){}_ '.includes(prefix))
+        if (provider && !' [ ] ( ) { } _ '.includes(prefix))
           new Promise (resolve) ->
             log.trace('ensime.getSuggestions')
             provider.getCompletions(editor.getBuffer(), bufferPosition, resolve)

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -341,7 +341,7 @@ module.exports = Ensime =
 
       getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         provider = getProvider()
-        if (provider && /[a-z]/i.test(prefix))
+        if (provider && /[a-z.]/i.test(prefix))
           new Promise (resolve) ->
             log.trace('ensime.getSuggestions')
             provider.getCompletions(editor.getBuffer(), bufferPosition, resolve)

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -341,7 +341,7 @@ module.exports = Ensime =
 
       getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         provider = getProvider()
-        if (provider && !' [ ] ( ) { } _ '.includes(prefix))
+        if (provider && /[a-z]/i.test(prefix))
           new Promise (resolve) ->
             log.trace('ensime.getSuggestions')
             provider.getCompletions(editor.getBuffer(), bufferPosition, resolve)

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -341,7 +341,7 @@ module.exports = Ensime =
 
       getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         provider = getProvider()
-        if (provider && !'[](){}'.includes(prefix))
+        if (provider && !'[](){}_'.includes(prefix))
           new Promise (resolve) ->
             log.trace('ensime.getSuggestions')
             provider.getCompletions(editor.getBuffer(), bufferPosition, resolve)


### PR DESCRIPTION
Hi! 

Thanks for a great plugin :). I've found it annoying autocompletion starts right after a closing character (`]`, `)`, `}`). Here's a proposal for a small change that would prevent triggering autocompletion in such cases. 

It's just a stub and could be possibly expanded into a full blown configurable option. Actually, there is also one more thing that could be tested against _prefix_ - the minimum word length option of _autocomplete-plus_ (`atom.config.get('autocomplete-plus.minimumWordLength')`. In that way, _ensime-atom_ could adhere to that setting of _autocomplete-plus_.

Anyway, please merge or reject if you think we could have a better place for that. I'm not an experienced atom dev ;) so it's just a little hack, though I hope you find it useful.

All the best,

szw
