### PR TITLE
Fix duplicate atom-text-editor in keymaps

### DIFF
--- a/keymaps/ensime.cson
+++ b/keymaps/ensime.cson
@@ -1,6 +1,3 @@
-'atom-text-editor':
-  'f4': 'ensime:go-to-definition'
-
 'atom-text-editor[data-grammar="source scala"]':
   'f2': 'ensime:lock-type-hover'
 
@@ -9,3 +6,4 @@
   'shift-cmd-t': 'ensime:search-public-symbol'
   'ctrl-alt-d': 'ensime:go-to-doc'
   'ctrl-alt-D': 'ensime:browse-doc'
+  'f4': 'ensime:go-to-definition'


### PR DESCRIPTION
This was causing Ensime to fail loading in the latest version of atom
1.12.5.