### PR TITLE
Fix style deprecation warnings, Atom no longer uses Shadow DOM.

### DIFF
--- a/lib/features/implicits.coffee
+++ b/lib/features/implicits.coffee
@@ -18,14 +18,14 @@ class Implicits
 
   showImplicits: ->
     b = @editor.getBuffer()
-    
+
     instance = @instanceLookup()
-        
+
     continuation = =>
       range = b.getRange()
       startO = b.characterIndexForPosition(range.start)
       endO = b.characterIndexForPosition(range.end)
-      
+
       @clearMarkers()
       instance.api.getImplicitInfo(b.getPath(), startO, endO).then (result) =>
         createMarker = (info) =>
@@ -42,11 +42,11 @@ class Implicits
           )
           @editor.decorateMarker(markerRange,
               type: 'highlight'
-              class: 'implicit'
+              class: 'syntax--implicit'
           )
           @editor.decorateMarker(markerSpot,
               type: 'line-number'
-              class: 'implicit'
+              class: 'syntax--implicit'
           )
 
         markers = (createMarker info for info in result.infos)
@@ -58,7 +58,7 @@ class Implicits
           continuation()
       else
         continuation()
-        
+
   showImplicitsAtCursor: ->
     pos = @editor.getCursorBufferPosition()
     markers = @findMarkers({type: 'implicit', containsPoint: pos})

--- a/styles/ensime.atom-text-editor.less
+++ b/styles/ensime.atom-text-editor.less
@@ -2,7 +2,7 @@
 @import "octicon-utf-codes";
 
 
-@implicit-class: .implicit;
+@implicit-class: ~".syntax--implicit";
 @implicit-gutter-icon:  @info;
 @implicit-gutter-background:  inherit;
 @implicit-gutter-color: @text-color-info;
@@ -32,8 +32,8 @@
   }
 }
 
-atom-text-editor, atom-text-editor::shadow {
-  .inline-marker(@implicit-class,@implicit-underline-color, @implicit-gutter-background,@implicit-gutter-icon, @implicit-gutter-color);
+atom-text-editor {
+  .inline-marker(@implicit-class, @implicit-underline-color, @implicit-gutter-background, @implicit-gutter-icon, @implicit-gutter-color);
 }
 
 implicit-info.select-list.popover-list {


### PR DESCRIPTION
This fixes the warnings outlined in #271. Note that the style class in
Less had to be escaped because the class now contains `-` which is a
reserved operator in Less.