### PR TITLE
Remap 'ensime:search-public-symbol'

### DIFF
--- a/keymaps/ensime.cson
+++ b/keymaps/ensime.cson
@@ -1,5 +1,5 @@
 'atom-text-editor':
-  'shift-cmd-t': 'ensime:search-public-symbol'
+  'f6': 'ensime:search-public-symbol'
   'ctrl-alt-D': 'ensime:browse-doc'
 
 'atom-text-editor[data-grammar="source scala"]':


### PR DESCRIPTION
Remaps the shortcut for `search-public-symbol` to F6. #290